### PR TITLE
fix: augment PATH on macOS so qmd's node shebang resolves under GUI launch

### DIFF
--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -15,8 +15,33 @@ const defaultExecAsync = promisify(exec);
 // Type for the async exec function
 export type ExecAsyncFn = (
 	command: string,
-	options?: { maxBuffer?: number; cwd?: string }
+	options?: { maxBuffer?: number; cwd?: string; env?: NodeJS.ProcessEnv }
 ) => Promise<{ stdout: string; stderr: string }>;
+
+/**
+ * Build an env that includes common package-manager bin dirs on PATH.
+ *
+ * GUI-launched apps on macOS (Dock/Finder/Spotlight) inherit a minimal PATH
+ * that excludes /opt/homebrew/bin and /usr/local/bin. Even when the user
+ * configures an absolute binaryPath, scripts with `#!/usr/bin/env node`
+ * shebangs (like qmd) fail because `env` can't find `node`. Augmenting PATH
+ * here lets the shebang resolve and lets qmd itself shell out to its own
+ * dependencies.
+ */
+function buildExecEnv(): NodeJS.ProcessEnv {
+	if (process.platform !== "darwin") {
+		return process.env;
+	}
+	const extras = ["/opt/homebrew/bin", "/usr/local/bin"];
+	const current = process.env.PATH ?? "";
+	const parts = current.split(":").filter(Boolean);
+	for (const p of extras) {
+		if (!parts.includes(p)) {
+			parts.push(p);
+		}
+	}
+	return { ...process.env, PATH: parts.join(":") };
+}
 
 // --- Types for QMD JSON output ---
 
@@ -196,6 +221,7 @@ export class QMDWrapper {
 			const { stdout, stderr } = await this.execAsync(command, {
 				maxBuffer: 10 * 1024 * 1024, // 10MB buffer for large outputs
 				cwd: this.vaultPath,
+				env: buildExecEnv(),
 			});
 			return { stdout, stderr };
 		} catch (error) {
@@ -253,6 +279,7 @@ export class QMDWrapper {
 				{
 					maxBuffer: 10 * 1024 * 1024,
 					cwd: this.vaultPath,
+					env: buildExecEnv(),
 				},
 				(error, stdout, stderr) => {
 					this.currentSearchProcess = null;


### PR DESCRIPTION
## Summary

- On macOS, Dock/Finder/Spotlight-launched Obsidian inherits a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) that excludes `/opt/homebrew/bin` and `/usr/local/bin`.
- Even when a user configures `qmdBinaryPath` to an absolute path, `qmd`'s `#!/usr/bin/env node` shebang fails to find `node`, so every command errors out. This reproduces 100% on Homebrew/Apple-Silicon installs where qmd was installed via `npm i -g @tobilu/qmd` and symlinked into `/opt/homebrew/bin`.
- The plugin only works for these users if they launch Obsidian from a terminal (e.g. `open -a Obsidian`), which inherits the shell's full PATH.

## Fix

Pass an augmented `env` to `exec()` in `QMDWrapper.execCommand` and `QMDWrapper.execSearchCommand` that appends `/opt/homebrew/bin` and `/usr/local/bin` to `PATH` on `darwin`. No-op on other platforms. Duplicate-safe.

Diff is ~28 lines, all in `src/qmd.ts`. No behavior change for users whose PATH is already correct, and no settings migration needed.

## Test plan

- [x] `npm test` — 32/32 pass (existing `ExecAsyncFn` type extended with optional `env`, tests inject their mocks the same way)
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Manual: with `qmdBinaryPath` left at the default `\"qmd\"` and Obsidian launched from the Dock on macOS 15 / Apple Silicon, semantic search now works. Previously errored at every command because the shebang couldn't find `node`.