### PR TITLE
fix: scope qmd searches to the vault's collection

### DIFF
--- a/src/qmd.test.ts
+++ b/src/qmd.test.ts
@@ -168,6 +168,26 @@ Collections
 			const calledCommand = mockExecAsync.mock.calls[0][0] as string;
 			expect(calledCommand).toContain('\\"');
 		});
+
+		it("should scope the search to the configured collection", async () => {
+			mockExecAsync.mockResolvedValueOnce({ stdout: "[]", stderr: "" });
+
+			await wrapper.semanticSearch("test query");
+
+			const calledCommand = mockExecAsync.mock.calls[0][0] as string;
+			expect(calledCommand).toContain('--collection "test-collection"');
+		});
+
+		it("should use the collection set via updateConfig", async () => {
+			wrapper.updateConfig("qmd", "other-collection", null);
+			mockExecAsync.mockResolvedValueOnce({ stdout: "[]", stderr: "" });
+
+			await wrapper.semanticSearch("test query");
+
+			const calledCommand = mockExecAsync.mock.calls[0][0] as string;
+			expect(calledCommand).toContain('--collection "other-collection"');
+			expect(calledCommand).not.toContain("test-collection");
+		});
 	});
 
 	describe("keywordSearch", () => {
@@ -186,6 +206,15 @@ Collections
 			expect(result.success).toBe(true);
 			expect(result.data).toHaveLength(1);
 			expect(result.data?.[0].path).toBe("note1.md");
+		});
+
+		it("should scope the search to the configured collection", async () => {
+			mockExecAsync.mockResolvedValueOnce({ stdout: "[]", stderr: "" });
+
+			await wrapper.keywordSearch("keyword test");
+
+			const calledCommand = mockExecAsync.mock.calls[0][0] as string;
+			expect(calledCommand).toContain('--collection "test-collection"');
 		});
 	});
 

--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -522,13 +522,15 @@ export class QMDWrapper {
 	}
 
 	/**
-	 * Perform semantic search (vsearch)
+	 * Perform semantic search (vsearch), scoped to this vault's collection
+	 * Note: an index can hold several collections, so an unscoped search
+	 * leaks in results from the others
 	 */
 	async semanticSearch(query: string): Promise<QMDCommandResult<QMDSearchResult[]>> {
 		return this.queueCommand(async () => {
 			try {
 				const escapedQuery = query.replace(/"/g, '\\"');
-				const cmd = this.buildBaseCommand("vsearch") + ` "${escapedQuery}" --json`;
+				const cmd = this.buildBaseCommand("vsearch") + ` "${escapedQuery}" --collection "${this.collectionName}" --json`;
 				const { stdout, stderr } = await this.execSearchCommand(cmd);
 
 				try {
@@ -555,13 +557,15 @@ export class QMDWrapper {
 	}
 
 	/**
-	 * Perform keyword search (search)
+	 * Perform keyword search (search), scoped to this vault's collection
+	 * Note: an index can hold several collections, so an unscoped search
+	 * leaks in results from the others
 	 */
 	async keywordSearch(query: string): Promise<QMDCommandResult<QMDSearchResult[]>> {
 		return this.queueCommand(async () => {
 			try {
 				const escapedQuery = query.replace(/"/g, '\\"');
-				const cmd = this.buildBaseCommand("search") + ` "${escapedQuery}" --json`;
+				const cmd = this.buildBaseCommand("search") + ` "${escapedQuery}" --collection "${this.collectionName}" --json`;
 				const { stdout, stderr } = await this.execSearchCommand(cmd);
 
 				try {


### PR DESCRIPTION
## Problem

`semanticSearch()` and `keywordSearch()` invoke `qmd vsearch` / `qmd search` without any collection filter, so they query the entire qmd index rather than the vault's own collection.

A qmd index can hold many collections. On my machine the index has five, two of which are separate Obsidian vaults. Searching from inside one vault returned notes from the other vaults, and from unrelated indexed folders. Opening such a result does nothing useful, since the file isn't in the current vault at all.

It also produces duplicates whenever a subfolder is registered as its own collection: my `work` vault is indexed as `work`, and its `Claude-Sessions/` subfolder is _also_ indexed as `sessions`, so every session note came back twice.

## Fix

Both search commands now pass `-c/--collection` with the collection name the plugin already resolves (the `collectionName` setting, or the name derived from the vault name):

```
qmd vsearch "query" --collection "my-vault" --json
```

Index maintenance (`status`, `update`, `embed`) is unchanged.

## Behavior change

This is a user-visible change for anyone whose index holds more than one collection: searches that previously returned cross-collection hits are now scoped to the vault.

## Note for pre-existing qmd users

`ensureCollection()` registers the collection under this same resolved name, so the two stay in sync in the normal flow. The one exception is a vault path already registered under a different name before the plugin was installed: `qmd collection add` refuses it, and searches then scope to a name that doesn't exist. Renaming the collection to match fixes it; worth a line in the README if you think it's likely enough.

## Testing

- Three new unit tests in `src/qmd.test.ts`: the flag is present for both search modes, and `updateConfig()` changes are picked up.
- `npm run build && npm test && npm run lint` all pass (35 tests).
- Verified the flag against the real CLI (qmd 2.1.0, five-collection index) and confirmed results stay within the named collection.
- Manually tested in two Obsidian vaults sharing one index: results are now vault-only, and the duplicate `sessions` hits are gone.
